### PR TITLE
fix: don't unregister callback before register

### DIFF
--- a/MediaCore/src/main/java/io/straas/android/media/demo/widget/PlayerControl.java
+++ b/MediaCore/src/main/java/io/straas/android/media/demo/widget/PlayerControl.java
@@ -46,7 +46,6 @@ public class PlayerControl implements MediaController.MediaPlayerControl {
                 mLastMediaMetadataCompat = metadata;
             }
         };
-        mMediaControllerCompat.unregisterCallback(mCallback);
         mMediaControllerCompat.registerCallback(mCallback);
         mLastMediaMetadataCompat = mMediaControllerCompat.getMetadata();
         processPlaybackState(mMediaControllerCompat.getPlaybackState(), mediaController);


### PR DESCRIPTION
Cause NoSuchElementException on 4.x