### PR TITLE
fix: workaround forcing okhttp version

### DIFF
--- a/MediaCore/build.gradle
+++ b/MediaCore/build.gradle
@@ -26,4 +26,8 @@ dependencies {
     // only for danmaku effect demo
     compile 'com.github.ctiao:DanmakuFlameMaster:0.5.4'
     compile "io.straas.android.sdk:straas-messaging-ui:${STRAAS_SDK_VERSION}"
+
+    compile('com.squareup.okhttp3:okhttp:3.4.2') {
+        force = true
+    }
 }


### PR DESCRIPTION
exoplayer:extension-okhttp will try to pull lastest okhttp, which will conflict with okhttp-ws in socket.io

see #37