### PR TITLE
fix: missing en quality_select string key and remove unused quality_high

### DIFF
--- a/MediaCore/src/main/res/values/strings.xml
+++ b/MediaCore/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="quality_auto">Auto</string>
-    <string name="quality_high">High</string>
+    <string name="quality_select">Quality</string>
     <string name="quality_source">Source</string>
 
     <string name="common_cancel">Cancel</string>


### PR DESCRIPTION
due to removing the wrong key string